### PR TITLE
Rear-body, 3 stage damage detection

### DIFF
--- a/Client.lua
+++ b/Client.lua
@@ -151,7 +151,7 @@ function GetBodyState(vehicle,front,leftSide)
         end
     elseif not front then 
         local tailLight = GetEntityBoneIndexByName(vehicle,taillightBoneNames[leftSide])
-        if GetEntityBoneRotation(vehicle,tailLight) == vector3(0,0,0) then 
+        if GetEntityBoneRotation(vehicle,tailLight) == vector3(0,0,0) and not isBroken and not isBouncing then 
             return 1 
         end
     end 

--- a/Client.lua
+++ b/Client.lua
@@ -111,7 +111,7 @@ function GetDoorHealth(vehicle, doorIndex)
     if doorBroken then
         return 3
     elseif windowBroken then
-        return 1
+        return 2
     else
         return 0
     end
@@ -297,9 +297,4 @@ CreateThread(function()
         ::continue::
         lastVehicle = vehicle
     end
-end)
-
-
-AddEventHandler("CEventVehicleCollision", function(p1,p2,p3)
-    print("fired")
 end)

--- a/Client.lua
+++ b/Client.lua
@@ -121,6 +121,12 @@ local headlightFunctions = {
     [true]=GetIsLeftVehicleHeadlightDamaged,
     [false]=GetIsRightVehicleHeadlightDamaged
 }
+
+local taillightBoneNames = {
+    [true]="taillight_l",
+    [false]="taillight_r"
+}
+
 function GetBodyState(vehicle,front,leftSide)
     local isBouncing = IsVehicleBumperBouncing(vehicle,front)
     local isBroken = IsVehicleBumperBrokenOff(vehicle,front) and isBouncing
@@ -129,6 +135,11 @@ function GetBodyState(vehicle,front,leftSide)
         local headlightBroken = headlightFunctions[leftSide](vehicle)
         if headlightBroken and not isBroken and not isBouncing then 
             return 1
+        end
+    elseif not front then 
+        local tailLight = GetEntityBoneIndexByName(vehicle,taillightBoneNames[leftSide])
+        if GetEntityBoneRotation(vehicle,tailLight) == vector3(0,0,0) then 
+            return 1 
         end
     end 
 


### PR DESCRIPTION
There are 2 bones called "taillight_l" and "taillight_r", which represent the backlights as expected.
After some experiment I found that the **ROTATION** of these bones become vector3(0,0,0) after the light is broken. 
Did some experiment with the **POSITION** too but that didn't work out as expected.

This might need some more testing to make sure the taillight can never be vector3(0,0,0) without being broken.
Currently | Back body 3 stage
1st - Left/Right taillight broken
2nd - Bumper bouncing
3rd - Bumper broken